### PR TITLE
Unhighlight the icon when invoking a short-hold action

### DIFF
--- a/SwipyFolders.xm
+++ b/SwipyFolders.xm
@@ -465,7 +465,7 @@ CPDistributedMessagingCenter *messagingCenter;
 
 				[iconView sf_method:[iconView getFolderSetting:@"ShortHoldMethod" withDefaultSetting:shortHoldMethod withDefaultCustomAppIndex:shortHoldMethodCustomAppIndex] withForceTouch:NO];
 				lastTouchedTime = nil;
-				
+				iconView.highlighted = NO;
 				return;
 			} else if(!forceTouchRecognized && doubleTapMethod != 0) {
 				if (iconView == tappedIcon) {

--- a/SwipyFolders.xm
+++ b/SwipyFolders.xm
@@ -473,7 +473,7 @@ CPDistributedMessagingCenter *messagingCenter;
 						doubleTapRecognized = YES;
 
 						[iconView sf_method:[iconView getFolderSetting:@"DoubleTapMethod" withDefaultSetting:doubleTapMethod withDefaultCustomAppIndex:doubleTapMethodCustomAppIndex] withForceTouch:NO];
-						lastTappedTime = 0;
+						lastTappedTime = nil;
 						iconView.highlighted = NO;
 						return;
 					}


### PR DESCRIPTION
This fixes #8.
